### PR TITLE
Add props to custom className to Field Component

### DIFF
--- a/spec/components/Field.spec.js
+++ b/spec/components/Field.spec.js
@@ -9,7 +9,7 @@ enzymeConfig();
 describe('Field', () => {
   it('renders defaultProps', () => {
     const component = renderer.create(
-      <Field label='test' id='test' errorMessage='Erro!' value='test value' isFluid={true}>
+      <Field label='test' id='test' errorMessage='Erro!' value='test value' wrapperStyle='form__field'>
         <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
       </Field>,
     );
@@ -53,28 +53,30 @@ describe('Field', () => {
         expect(component.instance().style).not.toMatch(/--invalid/);
       });
     });
+  });
 
-    describe('with isFluid', () => {
-      it('returns className contains form__field--fluid', () => {
+  describe('.props', () => {
+    describe('wrapperStyle is not defined ', () => {
+      it('returns default value className', () => {
         const component = shallow(
-          <Field label='test' id='bora-pra-action' isFluid={true}>
+          <Field label='test' id='bora-pra-action' >
             <Input id='bora-pra-action' name='nameTest' onFieldChange={() => { }} />
           </Field>,
         );
 
-        expect(component.instance().wrapperStyle).toMatch(/form__field--fluid/);
+        expect(component.instance().props.wrapperStyle).toEqual('form__field form__field--fluid input');
       });
     });
 
-    describe('without isFluid', () => {
-      it('returns className not contains form__field--fluid', () => {
+    describe('wrapperStyle is defined ', () => {
+      it('returns custom className', () => {
         const component = shallow(
-          <Field label='test' id='bora-pra-action' isFluid={false}>
+          <Field label='test' id='bora-pra-action' wrapperStyle='custom__field'>
             <Input id='bora-pra-action' name='nameTest' onFieldChange={() => { }} />
           </Field>,
         );
 
-        expect(component.instance().wrapperStyle).not.toMatch(/form__field--fluid/);
+        expect(component.instance().props.wrapperStyle).toEqual('custom__field');
       });
     });
   });

--- a/spec/components/Field.spec.js
+++ b/spec/components/Field.spec.js
@@ -9,8 +9,8 @@ enzymeConfig();
 describe('Field', () => {
   it('renders defaultProps', () => {
     const component = renderer.create(
-      <Field label={'test'} id={'test'} errorMessage={'Erro!'} value={'test value'} isFluid={true}>
-        <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => {}} />
+      <Field label='test' id='test' errorMessage='Erro!' value='test value' isFluid={true}>
+        <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
       </Field>,
     );
 
@@ -21,8 +21,8 @@ describe('Field', () => {
 
   it('label htmlFor matches id prop', () => {
     const component = shallow(
-      <Field label={'test'} id={'bora-pra-action'}>
-        <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => {}} />
+      <Field label='test' id='bora-pra-action'>
+        <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
       </Field>,
     );
 
@@ -33,8 +33,8 @@ describe('Field', () => {
     describe('with erroMessage', () => {
       it('returns string containing --invalid', () => {
         const component = shallow(
-          <Field label={'test'} id={'bora-pra-action'} errorMessage={'Erro!'}>
-            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => {}} />
+          <Field label='test' id='bora-pra-action' errorMessage='Erro!'>
+            <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
           </Field>,
         );
 
@@ -45,8 +45,8 @@ describe('Field', () => {
     describe('without erroMessage', () => {
       it('returns string not containing --invalid', () => {
         const component = shallow(
-          <Field label={'test'} id={'bora-pra-action'}>
-            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => {}} />
+          <Field label='test' id='bora-pra-action'>
+            <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
           </Field>,
         );
 
@@ -57,8 +57,8 @@ describe('Field', () => {
     describe('with isFluid', () => {
       it('returns className contains form__field--fluid', () => {
         const component = shallow(
-          <Field label={'test'} id={'bora-pra-action'} isFluid={true}>
-            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => { }} />
+          <Field label='test' id='bora-pra-action' isFluid={true}>
+            <Input id='bora-pra-action' name='nameTest' onFieldChange={() => { }} />
           </Field>,
         );
 
@@ -69,8 +69,8 @@ describe('Field', () => {
     describe('without isFluid', () => {
       it('returns className not contains form__field--fluid', () => {
         const component = shallow(
-          <Field label={'test'} id={'bora-pra-action'} isFluid={false}>
-            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => { }} />
+          <Field label='test' id='bora-pra-action' isFluid={false}>
+            <Input id='bora-pra-action' name='nameTest' onFieldChange={() => { }} />
           </Field>,
         );
 

--- a/spec/components/Field.spec.js
+++ b/spec/components/Field.spec.js
@@ -9,7 +9,7 @@ enzymeConfig();
 describe('Field', () => {
   it('renders defaultProps', () => {
     const component = renderer.create(
-      <Field label={'test'} id={'test'} errorMessage={'Erro!'} value={'test value'}>
+      <Field label={'test'} id={'test'} errorMessage={'Erro!'} value={'test value'} isFluid={true}>
         <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => {}} />
       </Field>,
     );
@@ -51,6 +51,30 @@ describe('Field', () => {
         );
 
         expect(component.instance().style).not.toMatch(/--invalid/);
+      });
+    });
+
+    describe('with isFluid', () => {
+      it('returns className contains form__field--fluid', () => {
+        const component = shallow(
+          <Field label={'test'} id={'bora-pra-action'} isFluid={true}>
+            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => { }} />
+          </Field>,
+        );
+
+        expect(component.instance().wrapperStyle).toMatch(/form__field--fluid/);
+      });
+    });
+
+    xdescribe('without isFluid', () => {
+      it('returns className not contains form__field--fluid', () => {
+        const component = shallow(
+          <Field label={'test'} id={'bora-pra-action'} isFluid={false}>
+            <Input id={'bora-pra-action'} name={'nameTest'} onFieldChange={() => { }} />
+          </Field>,
+        );
+
+        expect(component.instance().wrapperStyle).not.toMatch(/form__field--fluid/);
       });
     });
   });

--- a/spec/components/Field.spec.js
+++ b/spec/components/Field.spec.js
@@ -9,7 +9,7 @@ enzymeConfig();
 describe('Field', () => {
   it('renders defaultProps', () => {
     const component = renderer.create(
-      <Field label='test' id='test' errorMessage='Erro!' value='test value' wrapperStyle='form__field'>
+      <Field label='test' id='test' errorMessage='Erro!' value='test value' wrapperClassName='form__field'>
         <Input id='bora-pra-action' name='nameTest' onFieldChange={() => {}} />
       </Field>,
     );
@@ -56,7 +56,7 @@ describe('Field', () => {
   });
 
   describe('.props', () => {
-    describe('wrapperStyle is not defined ', () => {
+    describe('wrapperClassName is not defined ', () => {
       it('returns default value className', () => {
         const component = shallow(
           <Field label='test' id='bora-pra-action' >
@@ -64,19 +64,19 @@ describe('Field', () => {
           </Field>,
         );
 
-        expect(component.instance().props.wrapperStyle).toEqual('form__field form__field--fluid input');
+        expect(component.instance().props.wrapperClassName).toEqual('form__field form__field--fluid input');
       });
     });
 
-    describe('wrapperStyle is defined ', () => {
+    describe('wrapperClassName is defined ', () => {
       it('returns custom className', () => {
         const component = shallow(
-          <Field label='test' id='bora-pra-action' wrapperStyle='custom__field'>
+          <Field label='test' id='bora-pra-action' wrapperClassName='custom__field'>
             <Input id='bora-pra-action' name='nameTest' onFieldChange={() => { }} />
           </Field>,
         );
 
-        expect(component.instance().props.wrapperStyle).toEqual('custom__field');
+        expect(component.instance().props.wrapperClassName).toEqual('custom__field');
       });
     });
   });

--- a/spec/components/Field.spec.js
+++ b/spec/components/Field.spec.js
@@ -66,7 +66,7 @@ describe('Field', () => {
       });
     });
 
-    xdescribe('without isFluid', () => {
+    describe('without isFluid', () => {
       it('returns className not contains form__field--fluid', () => {
         const component = shallow(
           <Field label={'test'} id={'bora-pra-action'} isFluid={false}>

--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -164,7 +164,7 @@ Array [
             }
         />
         <div
-            className="form__field form__field--fluid input"
+            className="form__field input"
         >
             <label
                 className="form__label"

--- a/spec/components/__snapshots__/Field.spec.js.snap
+++ b/spec/components/__snapshots__/Field.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Field renders defaultProps 1`] = `
 <div
-  className="form__field form__field--fluid input"
+  className="form__field"
 >
   <label
     className="form__label"

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -7,7 +7,7 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   errorMessage: PropTypes.string,
   value: PropTypes.string,
-  isFluid: PropTypes.Boolean,
+  isFluid: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -7,20 +7,19 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   errorMessage: PropTypes.string,
   value: PropTypes.string,
-  isFluid: PropTypes.bool,
+  wrapperStyle: PropTypes.string,
 };
 
 const defaultProps = {
   errorMessage: '',
   value: '',
-  isFluid: true,
+  wrapperStyle: 'form__field form__field--fluid input',
 };
 
 export default class Field extends Component {
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
 
-    this.wrapperStyle = this.props.isFluid ? 'form__field form__field--fluid input' : 'form__field input';
     this.spanStyle = 'form__message form__message--invalid space-element-small error';
   }
 
@@ -34,7 +33,7 @@ export default class Field extends Component {
 
   render() {
     return (
-      <div className={this.wrapperStyle}>
+      <div className={this.props.wrapperStyle}>
         <label htmlFor={this.props.id} className="form__label">
           { this.props.label }
         </label>

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -7,13 +7,13 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   errorMessage: PropTypes.string,
   value: PropTypes.string,
-  wrapperStyle: PropTypes.string,
+  wrapperClassName: PropTypes.string,
 };
 
 const defaultProps = {
   errorMessage: '',
   value: '',
-  wrapperStyle: 'form__field form__field--fluid input',
+  wrapperClassName: 'form__field form__field--fluid input',
 };
 
 export default class Field extends Component {
@@ -33,7 +33,7 @@ export default class Field extends Component {
 
   render() {
     return (
-      <div className={this.props.wrapperStyle}>
+      <div className={this.props.wrapperClassName}>
         <label htmlFor={this.props.id} className="form__label">
           { this.props.label }
         </label>

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -7,18 +7,20 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   errorMessage: PropTypes.string,
   value: PropTypes.string,
+  isFluid: PropTypes.Boolean,
 };
 
 const defaultProps = {
   errorMessage: '',
   value: '',
+  isFluid: true,
 };
 
 export default class Field extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
-    this.wrapperStyle = 'form__field form__field--fluid input';
+    this.wrapperStyle = this.props.isFluid ? 'form__field form__field--fluid input' : 'form__field input';
     this.spanStyle = 'form__message form__message--invalid space-element-small error';
   }
 

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -37,7 +37,7 @@ export default class Step extends Component {
               label={item.title}
               id={item.id}
               errorMessage={item.errorMessage}
-              isFluid={item.isFluid}>
+              wrapperStyle={item.wrapperStyle} >
               {
                 Factory.getComponent({
                   item,

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -37,7 +37,7 @@ export default class Step extends Component {
               label={item.title}
               id={item.id}
               errorMessage={item.errorMessage}
-              wrapperStyle={item.wrapperStyle} >
+              wrapperClassName={item.wrapperClassName} >
               {
                 Factory.getComponent({
                   item,

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -36,7 +36,8 @@ export default class Step extends Component {
               key={`field-${index}`}
               label={item.title}
               id={item.id}
-              errorMessage={item.errorMessage}>
+              errorMessage={item.errorMessage}
+              isFluid={item.isFluid}>
               {
                 Factory.getComponent({
                   item,

--- a/src/form.json
+++ b/src/form.json
@@ -77,6 +77,7 @@
             "name": "4_zipcode",
             "placeholder": "00000-000",
             "value": null,
+            "isFluid": false,
             "values": []
           },
           {

--- a/src/form.json
+++ b/src/form.json
@@ -77,7 +77,7 @@
             "name": "4_zipcode",
             "placeholder": "00000-000",
             "value": null,
-            "wrapperStyle": "form__field input",
+            "wrapperClassName": "form__field input",
             "values": []
           },
           {

--- a/src/form.json
+++ b/src/form.json
@@ -77,7 +77,7 @@
             "name": "4_zipcode",
             "placeholder": "00000-000",
             "value": null,
-            "isFluid": false,
+            "wrapperStyle": "form__field input",
             "values": []
           },
           {


### PR DESCRIPTION
### Description

In doing the implementation of Jason I saw that we were always rendering the class that forced the fields to be 100% of the width and in case we wanted that a field was not 100% of the width, to avoid overwrite of css in modifier class we created the props `wrapperClassName` to pass custom className.

### Changelog

* Add `wrapperClassName` props to field render custom className

### Printscreen

Before without `wrapperClassName` props:

![screen shot 2018-05-25 at 10 19 15](https://user-images.githubusercontent.com/6557202/40546254-2a2bcfea-6005-11e8-8ec6-1a25f1035672.png)

After with `wrapperClassName` props:

![screen shot 2018-05-25 at 10 18 43](https://user-images.githubusercontent.com/6557202/40546267-3578e37e-6005-11e8-8781-65b0a897cb27.png)
