### PR TITLE
Fix select render update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+**CHANGELOG** :memo:
+
+*
+
+**PRINTS** :framed_picture:

--- a/spec/components/Factory.spec.js
+++ b/spec/components/Factory.spec.js
@@ -50,6 +50,6 @@ describe('Factory', () => {
 
     expect(() => {
       Factory.getComponent({ item: invalidArg, ...commonProps });
-    }).toThrow('Invalid argument type');
+    }).toThrow(`JasonForm: Invalid component type: ${invalidArg.type}`);
   });
 });

--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -41,7 +41,7 @@ Array [
                 onBlur={[Function]}
                 onChange={[Function]}
                 required="true"
-                value="null"
+                value=""
             >
                 <option
                     value=""

--- a/spec/components/Select.spec.js
+++ b/spec/components/Select.spec.js
@@ -12,9 +12,9 @@ describe('Select', () => {
 
     const component = renderer.create(
       <Select
-        id={'idTest'}
-        name={'nameTest'}
-        placeholder={'placeholderTest'}
+        id='idTest'
+        name='nameTest'
+        placeholder='placeholderTest'
         required={false}
         onFieldChange={() => {}}
         values={values}
@@ -32,9 +32,9 @@ describe('Select', () => {
 
       const component = shallow(
         <Select
-          id={'idTest'}
-          name={'nameTest'}
-          placeholder={'placeholderTest'}
+          id='idTest'
+          name='nameTest'
+          placeholder='placeholderTest'
           required={false}
           onFieldChange={() => {}}
           values={values}
@@ -51,9 +51,9 @@ describe('Select', () => {
 
       const component = shallow(
         <Select
-          id={'idTest'}
-          name={'nameTest'}
-          placeholder={'placeholderTest'}
+          id='idTest'
+          name='nameTest'
+          placeholder='placeholderTest'
           required={false}
           initialValue='this is the initialValue'
           onFieldChange={() => {}}
@@ -73,9 +73,9 @@ describe('Select', () => {
     it('sets placeholder as first option', () => {
       const component = mount(
         <Select
-          id={'idTest'}
-          name={'nameTest'}
-          placeholder={'placeholderTest'}
+          id='idTest'
+          name='nameTest'
+          placeholder='placeholderTest'
           required={false}
           onFieldChange={() => {}}
           values={values}
@@ -88,9 +88,9 @@ describe('Select', () => {
     it('does not set placeholder', () => {
       const component = mount(
         <Select
-          id={'idTest'}
-          name={'nameTest'}
-          placeholder={''}
+          id='idTest'
+          name='nameTest'
+          placeholder=''
           required={false}
           onFieldChange={() => {}}
           values={values}
@@ -108,9 +108,9 @@ describe('Select', () => {
 
       const component = shallow(
         <Select
-          id={'idTest'}
-          name={'nameTest'}
-          placeholder={''}
+          id='idTest'
+          name='nameTest'
+          placeholder=''
           required={false}
           onFieldChange={onFieldChange}
           values={values}

--- a/spec/components/Select.spec.js
+++ b/spec/components/Select.spec.js
@@ -45,6 +45,26 @@ describe('Select', () => {
 
       expect(component.instance().state.value).toEqual('Reformas');
     });
+
+    it('onverrides initialValue', () => {
+      const values = form.steps[0].fields[0].values.slice(0, 2);
+
+      const component = shallow(
+        <Select
+          id={'idTest'}
+          name={'nameTest'}
+          placeholder={'placeholderTest'}
+          required={false}
+          initialValue='this is the initialValue'
+          onFieldChange={() => {}}
+          values={values}
+        />,
+      );
+
+      component.simulate('change', { target: { value: 'Reformas' } });
+
+      expect(component.instance().state.value).toEqual('Reformas');
+    });
   });
 
   describe('.addPlaceholder', () => {

--- a/spec/components/Select.spec.js
+++ b/spec/components/Select.spec.js
@@ -46,7 +46,7 @@ describe('Select', () => {
       expect(component.instance().state.value).toEqual('Reformas');
     });
 
-    it('onverrides initialValue', () => {
+    it('onverrides initialValue on change event', () => {
       const values = form.steps[0].fields[0].values.slice(0, 2);
 
       const component = shallow(

--- a/spec/components/__snapshots__/Step.spec.js.snap
+++ b/spec/components/__snapshots__/Step.spec.js.snap
@@ -26,7 +26,7 @@ exports[`Step renders with props 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       required="true"
-      value="null"
+      value=""
     >
       <option
         value=""

--- a/src/components/Factory.js
+++ b/src/components/Factory.js
@@ -54,6 +54,6 @@ export default class Factory {
       );
     }
 
-    throw new Error('Invalid argument type');
+    throw new Error(`JasonForm: Invalid component type: ${type}`);
   }
 }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -60,13 +60,13 @@ export default class Select extends Component {
   }
 
   render() {
-    const { id, name, initialValue, required, style } = this.props;
+    const { id, name, required, style } = this.props;
 
     return (
       <select
         id={id}
         name={name}
-        value={String(initialValue)}
+        value={this.state.value}
         className={style}
         onChange={this.onChange}
         onBlur={this.onBlur}


### PR DESCRIPTION
This PR includes a fix for the select component. After some refactoring we noticed that the value of the select only changes on `blur` event. That is because we changed the prop value to use `initialValue`.

**CHANGELOG** :memo:

* Fixed select component initial value
* Added PR template

**PRINTS** :framed_picture: