### PR TITLE
Fix input phone autocomplete

### DIFF
--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -288,16 +288,16 @@ Array [
         >
             <label
                 className="form__label"
-                htmlFor="user_field_4"
+                htmlFor="phone"
             >
                 DDD + Celular
             </label>
             <input
                 className="form__input"
-                id="user_field_4"
+                id="phone"
                 maxLength={255}
                 minLength={3}
-                name="user_field_4"
+                name="phone"
                 onBlur={[Function]}
                 onChange={[Function]}
                 placeholder=""

--- a/spec/components/Input.spec.js
+++ b/spec/components/Input.spec.js
@@ -112,5 +112,28 @@ describe('Input', () => {
 
       expect(component.instance().props.onFieldChange).toBeCalled();
     });
+
+    describe('when input is type phone', () => {
+      it('keeps state updated on blur event', () => {
+        const onFieldChange = jest.fn();
+
+        const component = mount(
+          <Input
+            id='phone'
+            name='phone'
+            type='phone'
+            onFieldChange={onFieldChange}
+            placeholder='(__) _____-____'
+            required={false}
+            value=''
+          />,
+        );
+
+        component.simulate('change', { target: { value: '(11) 99999-8888' } });
+        component.simulate('blur');
+
+        expect(component.state().value).toBe('(11) 99999-8888');
+      });
+    });
   });
 });

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -63,6 +63,7 @@ export default class Input extends Component {
 
     if (type === 'phone') {
       this.mask = new IMask(this.ref.current, { mask: '(00) 00000-0000' });
+      this.mask.on('complete', () => { this.setState({ value: this.mask.value }); });
     }
 
     this.setState({ initialValue });

--- a/src/form.json
+++ b/src/form.json
@@ -102,8 +102,8 @@
           },
           {
             "title": "DDD + Celular",
-            "id": "user_field_4",
-            "name": "user_field_4",
+            "id": "phone",
+            "name": "phone",
             "type": "phone",
             "placeholder": "",
             "required": true,


### PR DESCRIPTION
This PR includes a small fix for the component Input with type phone. We did not catch this before because we were using some random ID on the input markup ex: `id="user_field_4" name="user_field_4"`. After some tests with real world data, we discovered this little side effect when using the same component with a diferente ID like `id="phone" name="phone"`.

**CHANGELOG** :memo:

* Added callback to maintain mask state
* Added new spec

**PRINTS** :framed_picture:

### before: on blur the input is cleared
![input-phone](https://user-images.githubusercontent.com/178548/40625898-840639e6-628b-11e8-9c87-b3b69eb3a18c.gif)

### after: on blur the input keeps its value
![input-phone-ok](https://user-images.githubusercontent.com/178548/40625922-a724e058-628b-11e8-9bad-247f0335a9b7.gif)


