### PR TITLE
updates phone mask implementation

### DIFF
--- a/spec/components/Input.spec.js
+++ b/spec/components/Input.spec.js
@@ -158,4 +158,95 @@ describe('Input', () => {
       });
     });
   });
+
+  describe('.onChange', () => {
+    it('applies mask input', () => {
+      const onFieldChange = jest.fn();
+
+      const component = mount(
+        <Input
+          id='phone'
+          name='phone'
+          type='phone'
+          onFieldChange={onFieldChange}
+          onFieldBlur={() => {}}
+          placeholder='(__) _____-____'
+          required={false}
+          value=''
+        />,
+      );
+
+      const instance = component.instance();
+
+      component.simulate('change', { target: { value: '11999998888' } });
+
+      expect(instance.props.onFieldChange).toBeCalledWith({
+        id: 'phone',
+        value: '(11) 99999-8888',
+      });
+    });
+
+    it('calls applyMask onChange', () => {
+      const component = mount(
+        <Input
+          id='phone'
+          name='phone'
+          type='phone'
+          onFieldChange={() => {}}
+          onFieldBlur={() => {}}
+          placeholder='(__) _____-____'
+          required={false}
+          value=''
+        />,
+      );
+
+      const instance = component.instance();
+
+      instance.applyMask = jest.fn();
+
+      component.simulate('change', { target: { value: '11999998888' } });
+
+      expect(instance.applyMask).toBeCalledWith('11999998888');
+    });
+  });
+
+  describe('.applyMask', () => {
+    describe('when input type phone', () => {
+      it('returns masked value', () => {
+        const component = mount(
+          <Input
+            id='phone'
+            name='phone'
+            type='phone'
+            onFieldChange={() => {}}
+            onFieldBlur={() => {}}
+            placeholder='(__) _____-____'
+            required={false}
+            value=''
+          />,
+        );
+
+        expect(component.instance().applyMask('11999998888')).toBe('(11) 99999-8888');
+      });
+    });
+
+    describe('when input not of type phone', () => {
+      it('does not apply mask', () => {
+        const component = mount(
+          <Input
+            id='idTest'
+            name='idTest'
+            type='text'
+            onFieldChange={() => {}}
+            onFieldBlur={() => {}}
+            placeholder='(__) _____-____'
+            required={false}
+            value=''
+          />,
+        );
+
+        expect(component.instance().applyMask('John Doe')).toBe('John Doe');
+      });
+    });
+  });
 });

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,4 +1,4 @@
-import React, { Component, createRef } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import IMask from 'imask';
 import { maxLengthTrim, getInputType } from '../helpers/input';
@@ -29,18 +29,20 @@ const defaultProps = {
   maxLength: 255,
 };
 
+const mask = IMask.createMask({ mask: '(00) 00000-0000' });
+
 export default class Input extends Component {
   constructor(props) {
     super(props);
 
-    this.ref = createRef();
     this.onChange = this.onChange.bind(this);
     this.onBlur = this.onBlur.bind(this);
-    this.mask = null;
   }
 
   onChange(evt) {
-    const inputValue = maxLengthTrim(evt.target.value, this.props.maxLength);
+    let inputValue = maxLengthTrim(evt.target.value, this.props.maxLength);
+
+    inputValue = this.applyMask(inputValue);
 
     this.props.onFieldChange({
       value: inputValue,
@@ -58,18 +60,18 @@ export default class Input extends Component {
     });
   }
 
-  componentDidMount() {
-    const { type } = this.props;
-
-    if (type === 'phone') {
-      this.mask = new IMask(this.ref.current, { mask: '(00) 00000-0000' });
-      this.mask.on('complete', () => {
-        this.props.onFieldChange({
-          value: this.mask.value,
-          id: this.props.id,
-        });
-      });
+  applyMask(value) {
+    if (this.props.type !== 'phone') {
+      return value;
     }
+
+    return mask.resolve(value);
+  }
+
+  componentDidMount() {
+    const { initialValue } = this.props;
+
+    this.applyMask(initialValue || '');
   }
 
   render() {
@@ -99,7 +101,7 @@ export default class Input extends Component {
         onBlur={this.onBlur}
         minLength={minLength}
         maxLength={maxLength}
-        ref={this.ref} />
+      />
     );
   }
 }


### PR DESCRIPTION
This PR aims to fix a bug introduced in the previous PR https://github.com/getninjas/jason/pull/22, where when the phone was pre-filled the input mask stopped to work.

The solution was to remove the binding from the input and the mask library and handle only the raw input value.

**CHANGELOG** :memo:

* Detached the mask-input handler from the input
* Added new specs

**PRINTS** :framed_picture:
