### PR TITLE
Fix zipcode display

### DIFF
--- a/spec/components/Zipcode.spec.js
+++ b/spec/components/Zipcode.spec.js
@@ -175,6 +175,38 @@ describe('Zipcode', () => {
       expect(component.instance().setState).toHaveBeenCalled();
       expect(component.instance().props.onFieldChange).toHaveBeenCalled();
     });
+
+    describe('with empty street on response', () => {
+      it('does not display empty space with commma', async () => {
+        const onFieldChange = jest.fn();
+        const ZipcodeMock = getComponentWithContext();
+        const component = mount(<ZipcodeMock id='zip_id' name='zip_name' zipcodeUrlService='' onFieldBlur={() => {}} onFieldChange={ onFieldChange } mask='00000-000' />);
+        const instance = component.instance();
+        const responseData = {
+          data: { type_street: '', street: '', city: 'Cidade Mock', neighborhood: 'Bairro Mock', uf: 'SP' },
+        };
+
+        await instance.onZipcodeSuccess('04707060', responseData);
+
+        expect(instance.state.fullAddress).toBe('Bairro Mock \nCidade Mock - SP');
+      });
+    });
+
+    describe('with empty street and neighborhood', () => {
+      it('does not display empty space with commma', async () => {
+        const onFieldChange = jest.fn();
+        const ZipcodeMock = getComponentWithContext();
+        const component = mount(<ZipcodeMock id='zip_id' name='zip_name' zipcodeUrlService='' onFieldBlur={() => {}} onFieldChange={ onFieldChange } mask='00000-000' />);
+        const instance = component.instance();
+        const responseData = {
+          data: { type_street: '', street: '', city: 'Cidade Mock', neighborhood: '', uf: 'SP' },
+        };
+
+        await instance.onZipcodeSuccess('04707060', responseData);
+
+        expect(instance.state.fullAddress).toBe('Cidade Mock - SP');
+      });
+    });
   });
 
   describe('.onZipcodeError', () => {

--- a/spec/helpers/zipcode.spec.js
+++ b/spec/helpers/zipcode.spec.js
@@ -54,6 +54,62 @@ describe('fillAddressState', () => {
 
     expect(result).toEqual(newState);
   });
+
+  describe('full adddres without street', () => {
+    it('does not display empty space with comma', () => {
+      const zipcode = '13150000';
+      const responseAddress = {
+        street: '',
+        neighborhood: 'xpto neighborhood',
+        city: 'xpto city',
+        uf: 'xpto uf',
+      };
+
+      const fullAddress = `${responseAddress.neighborhood} \n${responseAddress.city} - ${responseAddress.uf}`;
+
+      const newState = {
+        value: '13150000',
+        fetchCompleted: true,
+        street: '',
+        neighborhood: 'xpto neighborhood',
+        city: 'xpto city',
+        uf: 'xpto uf',
+        fullAddress,
+      };
+
+      const result = fillAddressState(responseAddress, zipcode);
+
+      expect(result).toEqual(newState);
+    });
+  });
+
+  describe('full adddres without street and neighborhood', () => {
+    it('does not display empty space with comma', () => {
+      const zipcode = '13150000';
+      const responseAddress = {
+        street: '',
+        neighborhood: '',
+        city: 'xpto city',
+        uf: 'xpto uf',
+      };
+
+      const fullAddress = `${responseAddress.city} - ${responseAddress.uf}`;
+
+      const newState = {
+        value: '13150000',
+        fetchCompleted: true,
+        street: '',
+        neighborhood: '',
+        city: 'xpto city',
+        uf: 'xpto uf',
+        fullAddress,
+      };
+
+      const result = fillAddressState(responseAddress, zipcode);
+
+      expect(result).toEqual(newState);
+    });
+  });
 });
 
 

--- a/src/helpers/zipcode.js
+++ b/src/helpers/zipcode.js
@@ -15,9 +15,12 @@ export const getEmptyState = state =>
     return { ...output, [key]: defaultValue };
   }, {});
 
-const getFullAddress = ({ street, neighborhood, city, uf }) =>
-  `${street}, ${neighborhood} \n${city} - ${uf}`;
+const getFullAddress = ({ street, neighborhood, city, uf }) => {
+  const displayStreet = street ? `${street},` : '';
+  const displayNeighborhood = neighborhood ? `${neighborhood} \n` : '';
 
+  return `${displayStreet}${displayNeighborhood}${city} - ${uf}`;
+};
 
 export const fillAddressState = (responseAddress, zipcode) => {
   const result = Object.keys(responseAddress)

--- a/src/helpers/zipcode.js
+++ b/src/helpers/zipcode.js
@@ -16,7 +16,7 @@ export const getEmptyState = state =>
   }, {});
 
 const getFullAddress = ({ street, neighborhood, city, uf }) => {
-  const displayStreet = street ? `${street},` : '';
+  const displayStreet = street ? `${street}, ` : '';
   const displayNeighborhood = neighborhood ? `${neighborhood} \n` : '';
 
   return `${displayStreet}${displayNeighborhood}${city} - ${uf}`;


### PR DESCRIPTION
This PR aims to fix a display problem, when the response data from a zip code fetch, returns an object with some empty fields like street or neighborhood

**CHANGELOG** :memo:

* Handling empty street and neighborhood values on display
* Added new specs

**PRINTS** :framed_picture:
![screen shot 2018-10-30 at 10 05 57 am](https://user-images.githubusercontent.com/178548/47719932-6b7f2800-dc2b-11e8-80dd-7fa1602f1e72.png)
