### PR TITLE
Send entire error object

### DIFF
--- a/spec/components/Form/index.spec.js
+++ b/spec/components/Form/index.spec.js
@@ -166,6 +166,31 @@ describe('Form', () => {
       expect(component.instance().getFields).toBeCalled();
       expect(component.instance().props.onSubmitSuccess).toBeCalled();
     });
+
+    it('calls .props.onSubmitError, getFields', async () => {
+      const onSubmit = jest.fn();
+      const onSubmitError = jest.fn();
+      const error = new Error({
+        config: {},
+        data: '',
+        headers: {},
+        request: {},
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      const component = shallow(
+        <Form name={'form'} onSubmit={ onSubmit } onSubmitError={ onSubmitError } action={''} data={form} />,
+      );
+
+      component.instance().getFields = jest.fn();
+
+      await component.instance().submitRequest();
+
+      expect(component.instance().props.onSubmit).toBeCalled();
+      expect(component.instance().getFields).toBeCalled();
+      expect(component.instance().props.onSubmitError).toBeCalledWith(error);
+    });
   });
 
   describe('.isStepVisible', () => {

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -134,7 +134,7 @@ export default class Form extends Component {
 
       this.props.onSubmitSuccess(response);
     } catch (error) {
-      this.props.onSubmitError(error.response);
+      this.props.onSubmitError(error);
     }
   }
 

--- a/src/components/__mocks__/axios.js
+++ b/src/components/__mocks__/axios.js
@@ -6,6 +6,18 @@ export default {
     return Promise.resolve({ data: { type_street: '', street: 'Rua Mock', city: 'Cidade Mock', neighborhood: 'Bairro Mock', uf: 'SP' } });
   }),
   post: jest.fn((url, body) => {
+    if (!url.length) {
+      const error = new Error({
+        config: {},
+        data: '',
+        headers: {},
+        request: {},
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      return Promise.reject(error);
+    }
     return Promise.resolve({ data: { link: 'https://testdomain.com' } });
   }),
 };


### PR DESCRIPTION
**CHANGELOG** :memo:

* When the form was submitted with an error, Jason was sending `error.response` as an argument to the `_onSubmitError` method, but this argument is `undefined`, since the error object has the following keys: 

![Screen Shot 2019-05-29 at 15 31 09](https://user-images.githubusercontent.com/5607300/58581832-d119ae00-8226-11e9-8de3-65d781d55192.png)

So instead of sending `error.response`, Jason is now sending the entire `error` object, delegating to the receiver the responsibility to get what part of the error it wants.