### PR TITLE
Move form action from props to state

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,8 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.3
-ignore: {}
-# patches apply the minimum changes required to fix a vulnerability
-patch:
-  SNYK-JS-AXIOS-174505:
-    - axios:
-        patched: '2019-05-06T00:11:06.340Z'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ before_install:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-  - npm install -g snyk
 before_script:
   - npm install
   - npm install -g jest-cli
-  - snyk auth $SNYK_TOKEN
 script:
   - CI=false npm run build
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "version": "npm run build && git add -f build",
     "postversion": "git push && git push --tags",
     "config": "npm config set progress=false && npm config set git-tag-version=true",
-    "clear": "rm -rf ./build",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "clear": "rm -rf ./build"
   },
   "repository": {
     "type": "git",
@@ -149,6 +147,5 @@
     "not dead",
     "not ie >=11",
     "not op_mini all"
-  ],
-  "snyk": true
+  ]
 }

--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Form renders defaultProps 1`] = `
 Array [
   <form
+    action="/"
     className="form container sh-form-content space-box-small"
     name="form"
     noValidate={true}

--- a/spec/components/Form/index.spec.js
+++ b/spec/components/Form/index.spec.js
@@ -128,10 +128,11 @@ describe('Form', () => {
         const last = data.steps.length - 1;
         const userFields = data.steps[last];
 
-        Object.assign(userFields, { fields: [...mock] });
+        Object.assign(userFields, { fields: [...mock], action: 'https://updated/form/action' });
 
         component.instance().updateState(data);
 
+        expect(component.state().action).toBe('https://updated/form/action');
         expect(component.state().steps[last].fields).toBe(userFields.fields);
       });
     });

--- a/spec/components/Form/index.spec.js
+++ b/spec/components/Form/index.spec.js
@@ -128,12 +128,39 @@ describe('Form', () => {
         const last = data.steps.length - 1;
         const userFields = data.steps[last];
 
-        Object.assign(userFields, { fields: [...mock], action: 'https://updated/form/action' });
+        userFields.fields = [...mock];
+
+        component.instance().updateState(data);
+
+        expect(component.state().steps[last].fields).toBe(userFields.fields);
+      });
+    });
+
+    describe('with updated form action', () => {
+      it('matches action url', () => {
+        const data = copyState(form);
+        const component = shallow(
+          <Form name={'form'} data={data} action={'/'} />,
+        );
+
+        data.action = 'https://updated/form/action';
 
         component.instance().updateState(data);
 
         expect(component.state().action).toBe('https://updated/form/action');
-        expect(component.state().steps[last].fields).toBe(userFields.fields);
+      });
+    });
+
+    describe('without updated form action', () => {
+      it('matches initial action url', () => {
+        const data = copyState(form);
+        const component = shallow(
+          <Form name={'form'} data={data} action={'/'} />,
+        );
+
+        component.instance().updateState(data);
+
+        expect(component.state().action).toBe('/');
       });
     });
 

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -49,6 +49,7 @@ export default class Form extends Component {
         city: '',
         uf: '',
       },
+      action: this.props.action,
       steps: [],
     };
 
@@ -74,7 +75,7 @@ export default class Form extends Component {
   }
 
   updateState(state) {
-    Object.assign(state, { ...this.state });
+    Object.assign(state, { ...this.state, action: state.action });
 
     this.setState({ ...state });
   }
@@ -130,7 +131,7 @@ export default class Form extends Component {
       this.props.onSubmit();
 
       const body = this.getFields();
-      const response = await axios.post(this.props.action, body);
+      const response = await axios.post(this.state.action, body);
 
       this.props.onSubmitSuccess(response);
     } catch (error) {

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -74,12 +74,10 @@ export default class Form extends Component {
     }, this.props.onReady);
   }
 
-  updateState(newState) {
-    const localState = { ...this.state };
+  updateState(state) {
+    Object.assign(state, { ...this.state, action: state.action || this.props.action });
 
-    Object.assign(localState, { ...newState });
-
-    this.setState({ ...localState });
+    this.setState({ ...state });
   }
 
   onZipcodeFetchSuccess(data) {

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -74,10 +74,12 @@ export default class Form extends Component {
     }, this.props.onReady);
   }
 
-  updateState(state) {
-    Object.assign(state, { ...this.state, action: state.action });
+  updateState(newState) {
+    const localState = { ...this.state };
 
-    this.setState({ ...state });
+    Object.assign(localState, { ...newState });
+
+    this.setState({ ...localState });
   }
 
   onZipcodeFetchSuccess(data) {

--- a/src/form.json
+++ b/src/form.json
@@ -1,5 +1,17 @@
 {
   "form": {
+    "action": "/",
+    "activeStepIndex": 0,
+    "address": {
+      "city": "",
+      "neighborhood": "",
+      "street": "",
+      "typeStreet": "",
+      "uf": ""
+    },
+    "onZipcodeFetchError": {},
+    "onZipcodeFetchSuccess": {},
+    "stepsCount": 2,
     "language": "pt-BR",
     "title": "Form Title",
     "databaseId": 81,


### PR DESCRIPTION
This PR aims to make the form action easy to customize/update.

It also fixes a bug when using `form.update(state)` method and there is a different form action url from the initial render.

### Problem
We have a use case where we needed to update the form action url. This parameter is passed via `props` so it only renders once the initial value. 

### Solution
Append the props.action to the form internal state so we could handle updates via `form.update(newState)`

#### bonus
* Removing Snyk since Dependabot is also  verifying updates

**CHANGELOG** :memo:

* Moved form action from props to state

**PRINTS** :framed_picture:
