### PR TITLE
Fix text input with checkbox

### DIFF
--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -305,7 +305,11 @@ Array [
             <label
               htmlFor={6792}
             >
-              Cozinhar
+              <label
+                htmlFor={6792}
+              >
+                Cozinhar
+              </label>
             </label>
           </li>
           <li
@@ -324,7 +328,11 @@ Array [
             <label
               htmlFor={6793}
             >
-              Passar roupa
+              <label
+                htmlFor={6793}
+              >
+                Passar roupa
+              </label>
             </label>
           </li>
           <li
@@ -343,7 +351,11 @@ Array [
             <label
               htmlFor={6794}
             >
-              Limpar áreas externas (jardim/garagem ou quintal)
+              <label
+                htmlFor={6794}
+              >
+                Limpar áreas externas (jardim/garagem ou quintal)
+              </label>
             </label>
           </li>
           <li
@@ -362,7 +374,11 @@ Array [
             <label
               htmlFor={6795}
             >
-              Não preciso
+              <label
+                htmlFor={6795}
+              >
+                Não preciso
+              </label>
             </label>
           </li>
           <li
@@ -381,7 +397,11 @@ Array [
             <label
               htmlFor={7689}
             >
-              Outro
+              <label
+                htmlFor={7689}
+              >
+                Outro
+              </label>
             </label>
           </li>
           <li

--- a/spec/components/__snapshots__/Checkbox.spec.js.snap
+++ b/spec/components/__snapshots__/Checkbox.spec.js.snap
@@ -18,7 +18,11 @@ exports[`Checkbox render component 1`] = `
     <label
       htmlFor={6792}
     >
-      Cozinhar
+      <label
+        htmlFor={6792}
+      >
+        Cozinhar
+      </label>
     </label>
   </li>
 </ul>

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -107,7 +107,10 @@ export default class Checkbox extends Component {
                   data-id={elem.databaseId}
                   ref={this.ref}
                   onBlur={this.onBlurInputOther} />
-              ) : elem.value}
+              ) : <label key={`${elem.databaseId}-${idx}`} htmlFor={elem.databaseId}>
+                    {elem.value}
+                  </label>
+              }
             </label>
           </li>
         ))}


### PR DESCRIPTION
**DESCRIPTION** :memo:

This bug occurred in Safari browser when clicking on the checkbox and after a click on the input text

**CHANGELOG** :memo:

* Remove attribute for to checkbox in the input text 
