### PR TITLE
Reset dynamic field value when reference changes

### DIFF
--- a/spec/components/Form/index.spec.js
+++ b/spec/components/Form/index.spec.js
@@ -389,6 +389,23 @@ describe('Form', () => {
       expect(updatedState.steps[1].fields[2].values).toEqual(updatedOptions);
     });
 
+    it('resets dynamic selection when the reference changes', () => {
+      const component = shallow(
+        <Form name={'form'} action={'/'} data={form} />,
+      );
+      component.instance().nextStep({ activeStepIndex: 0, stepsCount: 3 });
+
+      // Select reference field
+      component.instance().onFieldChange({ value: 124, id: '10_id' });
+      // Select dynamic field
+      component.instance().onFieldChange({ value: 549, id: '09_sc' });
+      // Change reference field
+      component.instance().onFieldChange({ value: 154, id: '10_id' });
+
+      const updatedState = component.instance().state;
+      expect(updatedState.steps[1].fields[2].value).toBeNull();
+    });
+
     it('does not updated select with dynamic options', () => {
       const component = shallow(
         <Form name={'form'} action={'/'} data={form} />,

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -200,7 +200,7 @@ export default class Form extends Component {
       if (item.reference === id) {
         const defaultValue = { values: [{ databaseId: '', value: item.mask }] };
 
-        return { ...item, values: (item.nested_values[value] || defaultValue).values };
+        return { ...item, values: (item.nested_values[value] || defaultValue).values, value: null };
       }
 
       if (item.id === id) {


### PR DESCRIPTION
When a reference field changes, not only the values must be updated but
the also the current selected value must be reset.

This fixes #61

**CHANGELOG** :memo:

* resets the value when a reference changes

**PRINTS** :framed_picture:

:no_entry_sign: 