### PR TITLE
Grow 291 - Add full header markup and hide breadcrumb

### DIFF
--- a/spec/components/Form/__snapshots__/index.spec.js.snap
+++ b/spec/components/Form/__snapshots__/index.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Form renders defaultProps 1`] = `
 Array [
+  "",
   <form
     action="/"
     className="form container sh-form-content space-box-small"
@@ -17,14 +18,6 @@ Array [
         }
       }
     >
-      <div
-        className="__headerMarkup__"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<h2 class='widget__title section-title--high-contrast'>Lorem Ipsum is simply dummy text <small>It has survived not</small></h2>",
-          }
-        }
-      />
       <div
         className="form__field form__field--fluid input"
       >
@@ -112,14 +105,6 @@ Array [
         }
       }
     >
-      <div
-        className="__headerMarkup__"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<h2 class='widget__title section-title--high-contrast'>Lorem Ipsum is simply dummy text <small>It has survived not</small></h2>",
-          }
-        }
-      />
       <div
         className="form__field form__field--fluid input"
       >
@@ -461,14 +446,6 @@ Array [
         }
       }
     >
-      <div
-        className="__headerMarkup__"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<div class='form__alert-message space-element-large'><img src='https://www.getninjas.com.br/assets/request/phone_call.svg' class='form__icon' alt='Lorem Ipsum is simply dummy text of the printing and typesetting industry.'><h2 class='form__info'>Almost there<small>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's<strong>standard dummy text ever since the 1500s</strong></small></h2></div>",
-          }
-        }
-      />
       <div
         className="form__field input"
       >

--- a/spec/components/Step.spec.js
+++ b/spec/components/Step.spec.js
@@ -23,6 +23,7 @@ describe('Step', () => {
         onFieldChange={() => {}}
         onFieldBlur={() => {}}
         visible={true}
+        mustShowBreadcrumb={true}
       />,
     );
 
@@ -48,6 +49,7 @@ describe('Step', () => {
         onFieldChange={() => {}}
         onFieldBlur={() => {}}
         visible={true}
+        mustShowBreadcrumb={true}
       />,
     );
 
@@ -72,6 +74,7 @@ describe('Step', () => {
         onFieldBlur={() => {}}
         zipcodeUrlService={formData.form.zipcodeUrlService}
         visible={true}
+        mustShowBreadcrumb={true}
       />,
     );
 
@@ -100,6 +103,7 @@ describe('Step', () => {
           onFieldBlur={() => {}}
           zipcodeUrlService={formData.form.zipcodeUrlService}
           visible={true}
+          mustShowBreadcrumb={true}
         />,
       );
 
@@ -125,6 +129,7 @@ describe('Step', () => {
           onFieldBlur={() => {}}
           zipcodeUrlService={formData.form.zipcodeUrlService}
           visible={true}
+          mustShowBreadcrumb={true}
         />,
       );
 

--- a/spec/components/Step.spec.js
+++ b/spec/components/Step.spec.js
@@ -32,7 +32,32 @@ describe('Step', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('shows header html when exists', () => {
+  it('renders without breadcrumb', () => {
+    const step = formData.form.steps[0];
+
+    const component = renderer.create(
+      <Step
+        key={'step'}
+        buttonText={'next step'}
+        fields={step.fields}
+        formName={'formNameTest'}
+        onSubmit={() => {}}
+        isLast={false}
+        step={step}
+        zipcodeUrlService={formData.form.zipcodeUrlService}
+        onFieldChange={() => {}}
+        onFieldBlur={() => {}}
+        visible={true}
+        mustShowBreadcrumb={false}
+      />,
+    );
+
+    const tree = component.toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('do not show header html inside steps, even if is passed', () => {
     const step = formData.form.steps[0];
 
     const component = shallow(
@@ -55,7 +80,7 @@ describe('Step', () => {
 
     const result = component.html();
 
-    expect(result).toContain('widget__title');
+    expect(result).not.toContain('widget__title');
   });
 
   it('shows inputs, select and textarea inner component', () => {
@@ -86,7 +111,7 @@ describe('Step', () => {
     expect(result.includes('breadcrumb')).toBe(false);
   });
 
-  describe('.addHeaderMarkup', () => {
+  describe('.addHeaderMarkup does not exists inside steps', () => {
     it('does not add header markup', () => {
       const step = formData.form.steps[0];
 
@@ -112,7 +137,7 @@ describe('Step', () => {
       expect(result.includes('__headerMarkup__')).toBe(false);
     });
 
-    it('adds header markup', () => {
+    it('adds header markup will not work inside steps form', () => {
       const step = formData.form.steps[0];
 
       const component = shallow(
@@ -135,8 +160,8 @@ describe('Step', () => {
 
       const result = component.html();
 
-      expect(result.includes('__headerMarkup__')).toBe(true);
-      expect(result.includes('widget__title')).toBe(true);
+      expect(result.includes('__headerMarkup__')).toBe(false);
+      expect(result.includes('widget__title')).toBe(false);
     });
   });
 });

--- a/spec/components/__snapshots__/Step.spec.js.snap
+++ b/spec/components/__snapshots__/Step.spec.js.snap
@@ -9,7 +9,6 @@ exports[`Step renders with props 1`] = `
     }
   }
 >
-  
   <div
     className="form__field form__field--fluid input"
   >

--- a/spec/components/__snapshots__/Step.spec.js.snap
+++ b/spec/components/__snapshots__/Step.spec.js.snap
@@ -89,3 +89,93 @@ exports[`Step renders with props 1`] = `
   </button>
 </fieldset>
 `;
+
+exports[`Step renders without breadcrumb 1`] = `
+<fieldset
+  className="form__container inputs"
+  style={
+    Object {
+      "display": "block",
+    }
+  }
+>
+  <div
+    className="form__field form__field--fluid input"
+  >
+    <label
+      className="form__label"
+      htmlFor="radio_input"
+    >
+      What's the service?
+    </label>
+    <ul>
+      <li
+        className="form__radio"
+      >
+        <input
+          id={7890}
+          name="1_name_radio"
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={true}
+          type="radio"
+          value={7890}
+        />
+        <label
+          htmlFor={7890}
+        >
+          Category One
+        </label>
+      </li>
+      <li
+        className="form__radio"
+      >
+        <input
+          id={7891}
+          name="1_name_radio"
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={true}
+          type="radio"
+          value={7891}
+        />
+        <label
+          htmlFor={7891}
+        >
+          Category Two
+        </label>
+      </li>
+      <li
+        className="form__radio"
+      >
+        <input
+          id={7892}
+          name="1_name_radio"
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={true}
+          type="radio"
+          value={7892}
+        />
+        <label
+          htmlFor={7892}
+        >
+          Category Three
+        </label>
+      </li>
+    </ul>
+    <span
+      className="form__message form__message--invalid space-element-small error"
+    >
+      
+    </span>
+  </div>
+  <button
+    className="btn btn--regular btn--high-contrast btn--fluid space-box-medium"
+    onClick={[Function]}
+    type="button"
+  >
+    next step
+  </button>
+</fieldset>
+`;

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -5,6 +5,7 @@ import { AppContext } from '../../AppContext';
 import Breadcrumb from '../Breadcrumb';
 import Step from '../Step';
 import { validateField, validateStep } from './validation';
+import { addHeaderMarkup } from '../../helpers/step';
 
 const propTypes = {
   name: PropTypes.string.isRequired,
@@ -244,13 +245,15 @@ export default class Form extends Component {
   }
 
   render() {
+    const headerMarkup = this.state.activeStepIndex && this.state.steps[this.state.activeStepIndex].headerMarkup;
     return (
       <AppContext.Provider value={this.state}>
+        { addHeaderMarkup(headerMarkup) }
         <form noValidate onSubmit={this.onSubmit} name={this.props.name} action={this.state.action}
           className={this.formStyle}>
           {
             this.state.steps.map((step, index) => {
-              const { buttonText, headerMarkup, fields } = step;
+              const { buttonText, fields } = step;
 
               return (
                 <Step
@@ -258,7 +261,6 @@ export default class Form extends Component {
                   fields={fields}
                   formName={this.props.name}
                   onSubmit={this.onSubmit}
-                  headerMarkup={headerMarkup}
                   isLast={this.isLastStep(index)}
                   key={`${this.props.name}-step-${index}`}
                   onFieldBlur={this.onFieldBlur}

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -35,7 +35,7 @@ const defaultProps = {
   onSubmitFieldError() {},
   onSubmitError() {},
   onStepChange() {},
-  mustShowBreadcrumb: false,
+  mustShowBreadcrumb: true,
 };
 
 export default class Form extends Component {

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -21,6 +21,7 @@ const propTypes = {
   onSubmitError: PropTypes.func,
   onSubmit: PropTypes.func,
   onStepChange: PropTypes.func,
+  mustShowBreadcrumb: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -34,6 +35,7 @@ const defaultProps = {
   onSubmitFieldError() {},
   onSubmitError() {},
   onStepChange() {},
+  mustShowBreadcrumb: false,
 };
 
 export default class Form extends Component {
@@ -55,6 +57,7 @@ export default class Form extends Component {
       },
       action: this.props.action,
       steps: [],
+      mustShowBreadcrumb: this.props.mustShowBreadcrumb,
     };
 
     this.formStyle = 'form container sh-form-content space-box-small';
@@ -273,7 +276,9 @@ export default class Form extends Component {
           }
         </form>
 
-        <Breadcrumb active={this.state.activeStepIndex} steps={this.state.steps} />
+        { this.state.mustShowBreadcrumb
+          && <Breadcrumb active={this.state.activeStepIndex} steps={this.state.steps} />
+        }
       </AppContext.Provider>
     );
   }

--- a/src/components/Step.js
+++ b/src/components/Step.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Field from './Field';
 import Button from './Button';
 import Factory from './Factory';
-import { display, addHeaderMarkup } from '../helpers/step';
+import { display } from '../helpers/step';
 
 const propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -25,12 +25,10 @@ const defaultProps = {
 
 export default class Step extends Component {
   render() {
-    const { buttonText, headerMarkup, fields } = this.props;
+    const { buttonText, fields } = this.props;
 
     return (
       <fieldset className="form__container inputs" style={{ display: display(this.props.visible) }}>
-        { addHeaderMarkup(headerMarkup) }
-
         {
           fields.map((item, index) =>
             <Field

--- a/src/form.json
+++ b/src/form.json
@@ -318,6 +318,7 @@
           }
         ]
       }
-    ]
+    ],
+    "mustShowBreadcrumbs": true
   }
 }

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -34,6 +34,7 @@ class Jason {
         onSubmitFieldError={this.onSubmitFieldError}
         onSubmitError={this.onSubmitError}
         onStepChange={this.onStepChange}
+        mustShowBreadcrumb={this.mustShowBreadcrumb}
         ref={(component) => { this.form = component; }} />,
       this.element,
     );
@@ -53,6 +54,7 @@ const jason = new Jason({
   onSubmitError: data => data,
   onStepChange: () => { },
   element: document.getElementById('root'),
+  mustShowBreadcrumb: true,
 });
 
 jason.init();

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export default class Jason {
         onSubmitFieldError={ this.onSubmitFieldError }
         onSubmitError={ this.onSubmitError }
         onStepChange={ this.onStepChange }
+        mustShowBreadcrumb={this.mustShowBreadcrumb}
         ref={(component) => { this.form = component; }} />,
       this.element,
     );


### PR DESCRIPTION
**CHANGELOG** :memo:

* Move header markup to outside form tag to be styled as we want.
* Turn breadcrumb visibility optional, sometimes we don't need it.

**PRINTS** :framed_picture:
:no_entry: 
